### PR TITLE
Fix GitHub Pages routing redirects

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,32 @@
 
   <body>
     <div id="root"></div>
+    <script>
+      (function () {
+        const redirectPath = sessionStorage.getItem("spa_redirect");
+        if (!redirectPath) {
+          return;
+        }
+
+        sessionStorage.removeItem("spa_redirect");
+
+        const base = "%BASE_URL%".replace(/\/$/, "");
+
+        try {
+          const url = new URL(redirectPath, window.location.origin);
+          let pathname = url.pathname;
+
+          if (base && pathname.startsWith(base)) {
+            pathname = pathname.slice(base.length);
+          }
+
+          const newPath = `${base}${pathname}${url.search}${url.hash}`;
+          window.history.replaceState(null, "", newPath || "/");
+        } catch (error) {
+          console.error("SPA redirect failed", error);
+        }
+      })();
+    </script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Redirecting...</title>
+    <script>
+      (function () {
+        try {
+          const redirect = window.location.pathname + window.location.search + window.location.hash;
+          sessionStorage.setItem("spa_redirect", redirect);
+
+          const segments = window.location.pathname.split("/").filter(Boolean);
+          const base = segments.length > 0 ? `/${segments[0]}` : "";
+          const target = `${base}/`;
+
+          window.location.replace(target || "/");
+        } catch (error) {
+          console.error("Unable to handle redirect", error);
+        }
+      })();
+    </script>
+  </head>
+  <body>
+    <noscript>
+      <p>Esta página precisa de JavaScript para carregar corretamente.</p>
+      <p>
+        <a href="/kapoias-creative-hub/">Voltar para a página inicial.</a>
+      </p>
+    </noscript>
+  </body>
+</html>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,13 +14,15 @@ import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
 
+const basename = import.meta.env.BASE_URL.replace(/\/+$/, "");
+
 const App = () => (
   <QueryClientProvider client={queryClient}>
     <AppProvider>
       <TooltipProvider>
         <Toaster />
         <Sonner />
-        <BrowserRouter>
+        <BrowserRouter basename={basename || undefined}>
           <Layout>
             <Routes>
               <Route path="/" element={<Index />} />


### PR DESCRIPTION
## Summary
- configure the React router to respect the Vite base path when hosted on GitHub Pages
- add client-side redirects so direct deep links are restored after the static 404 response
- provide a GitHub Pages 404 document that forwards visitors back to the SPA entry point

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d1efb6bb408327af82c8a9ae4ea839