### PR TITLE
Fix production base path for kapoias.com.br deployment

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,7 +15,7 @@ export default defineConfig(({ mode }) => ({
       "@": path.resolve(__dirname, "./src"),
     },
   },
-  base: mode === "development" ? "/" : "/kapoias-creative-hub/",
+  base: "/",
   build: {
     outDir: "dist",
     assetsDir: "assets",


### PR DESCRIPTION
## Summary
- set the Vite base path to "/" for all environments so production assets load from the domain root

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc74c118508327a780d322b79790fa