### PR TITLE
Fix SPA redirect for custom domain

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,6 +21,9 @@
     <div id="root"></div>
     <script>
       (function () {
+        const baseFromVite = "%BASE_URL%";
+        sessionStorage.setItem("spa_base", baseFromVite);
+
         const redirectPath = sessionStorage.getItem("spa_redirect");
         if (!redirectPath) {
           return;

--- a/public/404.html
+++ b/public/404.html
@@ -11,12 +11,23 @@
           sessionStorage.setItem("spa_redirect", redirect);
 
           const segments = window.location.pathname.split("/").filter(Boolean);
-          const base = segments.length > 0 ? `/${segments[0]}` : "";
-          const target = `${base}/`;
+          const hostname = window.location.hostname.toLowerCase();
+          const isGitHubPages = hostname.endsWith(".github.io");
 
-          window.location.replace(target || "/");
+          let base = sessionStorage.getItem("spa_base") || "/";
+
+          if (isGitHubPages && segments.length > 0) {
+            base = `/${segments[0]}/`;
+          }
+
+          if (!base.endsWith("/")) {
+            base = `${base}/`;
+          }
+
+          window.location.replace(base);
         } catch (error) {
           console.error("Unable to handle redirect", error);
+          window.location.replace("/");
         }
       })();
     </script>
@@ -25,7 +36,7 @@
     <noscript>
       <p>Esta página precisa de JavaScript para carregar corretamente.</p>
       <p>
-        <a href="/kapoias-creative-hub/">Voltar para a página inicial.</a>
+        <a href="/">Voltar para a página inicial.</a>
       </p>
     </noscript>
   </body>


### PR DESCRIPTION
## Summary
- update the static 404 redirect script to detect GitHub Pages deployments and fall back to the configured base path when serving from a custom domain
- persist the Vite base URL in session storage so the SPA redirect logic can recover the original path after the fallback loads

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc78ac0ec48327a7e1912361cda455